### PR TITLE
Relabel 6 images from "Cannot answer" to "Object not found" (Images 200–284 review)

### DIFF
--- a/data/labels/205.json
+++ b/data/labels/205.json
@@ -6,9 +6,9 @@
       "question_id": 1,
       "question": "Trong ảnh có cái cốc nào không?",
       "question_type": "Existence Checking",
-      "answerable": 0,
+      "answerable": 1,
       "answers": [
-        "Không thể trả lời được câu hỏi dựa vào thông tin trong ảnh"
+        "Không"
       ],
       "tags": [
         "CUP"

--- a/data/labels/207.json
+++ b/data/labels/207.json
@@ -6,9 +6,9 @@
       "question_id": 1,
       "question": "Có chai nước nào trong ảnh không?",
       "question_type": "Existence Checking",
-      "answerable": 0,
+      "answerable": 1,
       "answers": [
-        "Không thể trả lời được câu hỏi dựa vào thông tin trong ảnh"
+        "Không"
       ],
       "tags": [
         "WATER_BOTTLE"

--- a/data/labels/227.json
+++ b/data/labels/227.json
@@ -6,9 +6,9 @@
       "question_id": 1,
       "question": "Có chiếc điều khiển nào trong ảnh không?",
       "question_type": "Existence Checking",
-      "answerable": 0,
+      "answerable": 1,
       "answers": [
-        "Không thể trả lời được câu hỏi dựa vào thông tin trong ảnh"
+        "Không"
       ],
       "tags": [
         "REMOTE"

--- a/data/labels/235.json
+++ b/data/labels/235.json
@@ -6,9 +6,9 @@
       "question_id": 1,
       "question": "Trong ảnh có cái ví nào không?",
       "question_type": "Existence Checking",
-      "answerable": 0,
+      "answerable": 1,
       "answers": [
-        "Không thể trả lời được câu hỏi dựa vào thông tin trong ảnh"
+        "Không"
       ],
       "tags": [
         "WALLET"

--- a/data/labels/237.json
+++ b/data/labels/237.json
@@ -6,9 +6,9 @@
       "question_id": 1,
       "question": "Trong ảnh có chiếc cốc nào không?",
       "question_type": "Existence Checking",
-      "answerable": 0,
+      "answerable": 1,
       "answers": [
-        "Không thể trả lời được câu hỏi dựa vào thông tin trong ảnh"
+        "Không"
       ],
       "tags": [
         "CUP"

--- a/data/labels/256.json
+++ b/data/labels/256.json
@@ -6,9 +6,9 @@
       "question_id": 1,
       "question": "Trong ảnh có xuất hiện chiếc cốc nào không?",
       "question_type": "Existence Checking",
-      "answerable": 0,
+      "answerable": 1,
       "answers": [
-        "Không thể trả lời được câu hỏi dựa vào thông tin trong ảnh"
+        "Không"
       ],
       "tags": [
         "CUP"


### PR DESCRIPTION
This PR reflects the results of a manual review of dataset images from ID 200 to 284. Most images in this range are overexposed, blurry, or contain indistinct objects. Although the model under testing might not yet differentiate these issues, we’ve decided to retain the dataset in its current form for consistency.

However, the labels for 6 specific images have been updated from "Cannot answer" to "Object not found" to more accurately represent their content.
Preview images of the relabeled files are included for reference.

No changes were made to image content—only label adjustments.